### PR TITLE
refactor: use SafeERC20 recommendations

### DIFF
--- a/contracts/veBalFeeInjector.sol
+++ b/contracts/veBalFeeInjector.sol
@@ -158,11 +158,11 @@ contract veBalFeeInjector is ConfirmedOwner, Pausable {
     require(tokens.length >= 1, "Must provide at least once token");
     IERC20[] memory oldTokens = managedTokens;
     for(uint i=0; i<oldTokens.length; i++){
-      SafeERC20.safeApprove(oldTokens[i], address(feeDistributor), 0);
+      SafeERC20.safeDecreaseAllowance(oldTokens[i], address(feeDistributor), 0);
   }
     emit tokensSet(tokens);
     for(uint i=0; i < tokens.length; i++){
-      SafeERC20.safeApprove(tokens[i],address(feeDistributor), 2**128);
+      SafeERC20.safeIncreaseAllowance(tokens[i],address(feeDistributor), 2**128);
     }
     managedTokens = tokens;
   }


### PR DESCRIPTION
usafe of `safeApprove` is not recommended anymore. See: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/566a774222707e424896c0c390a84dc3c13bdcb2/contracts/token/ERC20/utils/SafeERC20.sol#L38

